### PR TITLE
Add Parrotlet-v-lite-4b

### DIFF
--- a/karma/eval_datasets/clinical_note_generation_dataset.py
+++ b/karma/eval_datasets/clinical_note_generation_dataset.py
@@ -23,7 +23,7 @@ SPLIT = "test"  # Adjust as needed based on actual dataset splits
     DATASET_NAME,
     split=SPLIT,
     metrics=["json_rubric_evaluation"],
-    task_type="text_to_json_rubric_evaluation",
+    task_type="text_to_json",
 )
 class ClinicalNoteGenerationDataset(BaseMultimodalDataset):
     """

--- a/karma/eval_datasets/medical_records_parsing_dataset.py
+++ b/karma/eval_datasets/medical_records_parsing_dataset.py
@@ -24,7 +24,7 @@ SPLIT = "test"  # Adjust as needed based on actual dataset splits
     DATASET_NAME,
     split=SPLIT,
     metrics=["json_rubric_evaluation"],
-    task_type="multimodal_rubric_evaluation",
+    task_type="image_to_json",
     optional_args=["system_prompt"],
 )
 class MedicalRecordsParsingDataset(BaseMultimodalDataset):

--- a/karma/models/medgemma.py
+++ b/karma/models/medgemma.py
@@ -186,19 +186,20 @@ MedGemmaModel = ModelMeta(
         else "mps"
         if torch.mps.is_available()
         else "cpu",
-        "max_tokens": 1024,  # Sufficient for translation outputs
-        "temperature": 0.01,  # Lower temperature for more consistent translations
-        "top_p": 0.9,  # Nucleus sampling
+        "max_tokens": 1024,
+        "temperature": 0.01,
+        "top_p": 0.9, 
         "top_k": 50,
     },
     revision=None,
     reference=None,
     model_type=ModelType.TEXT_GENERATION,
-    modalities=[ModalityType.TEXT],
+    modalities=[ModalityType.TEXT, ModalityType.IMAGE],
     n_parameters=None,
     memory_usage_mb=None,
     max_tokens=None,
     embed_dim=None,
     framework=["PyTorch", "Transformers"],
 )
+
 register_model_meta(MedGemmaModel)

--- a/karma/models/parrotlet_v.py
+++ b/karma/models/parrotlet_v.py
@@ -71,9 +71,7 @@ class ParrotletVLiteLLM(MedGemmaLLM):
             torch_dtype=torch.bfloat16,
             trust_remote_code=True,
         )
-        self.processor = AutoProcessor.from_pretrained(
-            self.model_name_or_path, trust_remote_code=True
-        )
+        self.processor = self.model.processor
 
 
 ParrotletVLiteModel = ModelMeta(

--- a/karma/models/parrotlet_v.py
+++ b/karma/models/parrotlet_v.py
@@ -74,6 +74,25 @@ class ParrotletVLiteLLM(MedGemmaLLM):
         self.processor = self.model.processor
 
 
+    def run(self, inputs: List[DataLoaderIterable], **kwargs) -> List[str]:
+        model_inputs = self.preprocess(inputs)
+        results = self.model.model.generate(
+            **model_inputs,
+            max_new_tokens=self.max_tokens,
+            temperature=self.temperature,
+            top_p=self.top_p,
+            top_k=self.top_k,
+        )
+
+        # Extract only the newly generated tokens
+        input_length = model_inputs["input_ids"].shape[1]
+        outputs = [
+            self.processor.decode(results[i][input_length:], skip_special_tokens=True)
+            for i in range(len(results))
+        ]
+        return self.postprocess(outputs)
+
+
 ParrotletVLiteModel = ModelMeta(
     name="ekacare/parrotlet-v-lite-4b",
     description="Parrotlet-v-lite-4b model",

--- a/karma/models/parrotlet_v.py
+++ b/karma/models/parrotlet_v.py
@@ -1,0 +1,105 @@
+import logging
+import os
+from typing import Optional, List, Dict, Union
+
+import torch
+from PIL import Image
+from transformers import AutoModel, AutoProcessor
+from io import BytesIO
+from karma.data_models.dataloader_iterable import DataLoaderIterable
+from karma.models.medgemma import MedGemmaLLM
+from karma.data_models.model_meta import ModelMeta, ModalityType, ModelType
+from karma.registries.model_registry import register_model_meta
+
+logger = logging.getLogger(__name__)
+
+
+class ParrotletVLiteLLM(MedGemmaLLM):
+    """MedGemma language model with vision capabilities for medical applications."""
+
+    def __init__(
+        self,
+        model_name_or_path,
+        device: str,
+        max_tokens: int = 1024,
+        temperature: float = 0.7,
+        top_p: float = 0.9,
+        top_k: Optional[int] = None,
+        **kwargs,
+    ):
+        """
+        Initialize MedGemma LLM model.
+
+        Args:
+            model_name_or_path: Path to the model (HuggingFace model ID)
+            device: Device to use for inference ("auto", "cuda", "cpu")
+            max_tokens: Maximum tokens to generate
+            temperature: Sampling temperature
+            top_p: Top-p sampling parameter
+            top_k: Top-k sampling parameter
+            **kwargs: Additional model-specific parameters
+        """
+        # Initialize parent class
+        super().__init__(
+            model_name_or_path=model_name_or_path,
+            device=device,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            top_p=top_p,
+            top_k=top_k,
+            **kwargs,
+        )
+        self.model_name_or_path = model_name_or_path
+        self.device = device
+        self.max_tokens = max_tokens
+        self.temperature = temperature
+        self.top_p = top_p
+        self.top_k = top_k
+
+    def load_model(self):
+        # authenticate HF
+        from huggingface_hub import login
+
+        try:
+            login(os.getenv("HF_TOKEN"))
+        except ValueError:
+            logger.warning("HF token not found, will not login.")
+
+        self.model = AutoModel.from_pretrained(
+            self.model_name_or_path,
+            device_map=self.device,
+            torch_dtype=torch.bfloat16,
+            trust_remote_code=True,
+        )
+        self.processor = AutoProcessor.from_pretrained(
+            self.model_name_or_path, trust_remote_code=True
+        )
+
+
+ParrotletVLiteModel = ModelMeta(
+    name="ekacare/parrotlet-v-lite-4b",
+    description="Parrotlet-v-lite-4b model",
+    loader_class="karma.models.parrotlet_v.ParrotletVLiteLLM",
+    loader_kwargs={
+        "device": "cuda"
+        if torch.cuda.is_available()
+        else "mps"
+        if torch.mps.is_available()
+        else "cpu",
+        "max_tokens": 1024,
+        "temperature": 0.01,
+        "top_p": 0.9, 
+        "top_k": 50,
+    },
+    revision=None,
+    reference=None,
+    model_type=ModelType.TEXT_GENERATION,
+    modalities=[ModalityType.TEXT, ModalityType.IMAGE],
+    n_parameters=None,
+    memory_usage_mb=None,
+    max_tokens=None,
+    embed_dim=None,
+    framework=["PyTorch", "Transformers"],
+)
+
+register_model_meta(ParrotletVLiteModel)


### PR DESCRIPTION
until now, we were using `google/medgemma-4b-it` class and pass path to parrotlet-v-lite's weights to evaluate it.

This PR implements parrotlet-v-lite's own class to load and use it as a standalone model.